### PR TITLE
feat: add dark mode toggle and update placeholder text

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,7 +4,7 @@ import InstallPWA from './components/InstallPWA'
 
 function App() {
   return (
-    <div className="min-h-screen">
+    <div className="min-h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 transition-colors">
       <Navbar />
       <main>
         <AppRoutes />

--- a/src/__tests__/Navbar.a11y.test.jsx
+++ b/src/__tests__/Navbar.a11y.test.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import Navbar from '../components/Navbar'
+import { ThemeProvider } from '../contexts/ThemeContext'
 
 jest.mock('../hooks/useAuth', () => {
   return jest.fn(() => ({
@@ -11,11 +12,28 @@ jest.mock('../hooks/useAuth', () => {
   }))
 })
 
+// Mock window.matchMedia
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+})
+
 test('Navbar renders with accessible navigation and buttons', () => {
   render(
-    <MemoryRouter>
-      <Navbar />
-    </MemoryRouter>
+    <ThemeProvider>
+      <MemoryRouter>
+        <Navbar />
+      </MemoryRouter>
+    </ThemeProvider>
   )
 
   // Navbar should have a navigation element or be semantically structured
@@ -40,9 +58,11 @@ test('Navbar renders with accessible navigation and buttons', () => {
 
 test('Navbar displays user info when authenticated', () => {
   render(
-    <MemoryRouter>
-      <Navbar />
-    </MemoryRouter>
+    <ThemeProvider>
+      <MemoryRouter>
+        <Navbar />
+      </MemoryRouter>
+    </ThemeProvider>
   )
 
   // Login button should be present when user is not authenticated

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import toast from 'react-hot-toast'
 import useAuth from '../hooks/useAuth'
+import ThemeToggle from './ThemeToggle'
 
 export default function Navbar() {
   const { user, loading, signOut } = useAuth();
@@ -21,18 +22,19 @@ export default function Navbar() {
   };
 
   return (
-    <nav className="w-full bg-white border-b border-gray-100 sticky top-0 z-50">
+    <nav className="w-full bg-white dark:bg-gray-900 border-b border-gray-100 dark:border-gray-800 sticky top-0 z-50 transition-colors">
       <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between h-16 items-center">
           <div className="flex items-center gap-6">
-            <Link to="/" className="text-xl font-bold text-gray-900">Tujitume</Link>
+            <Link to="/" className="text-xl font-bold text-gray-900 dark:text-white">Tujitume</Link>
             <div className="hidden sm:flex gap-6">
-              <Link to="/gigs" className="text-sm text-gray-600 hover:text-gray-900">Browse</Link>
-              <Link to="/post-gig" className="text-sm text-gray-600 hover:text-gray-900">Post Gig</Link>
+              <Link to="/gigs" className="text-sm text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white">Browse</Link>
+              <Link to="/post-gig" className="text-sm text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white">Post Gig</Link>
             </div>
           </div>
 
           <div className="flex items-center gap-4">
+            <ThemeToggle />
             {!loading && !user && (
               <>
                 <Link to="/login" className="text-sm px-4 py-2 bg-gray-900 text-white rounded hover:bg-gray-800">Login</Link>

--- a/src/components/PostGigForm.jsx
+++ b/src/components/PostGigForm.jsx
@@ -174,7 +174,7 @@ const PostGigForm = () => {
           type="text"
           value={formData.title}
           onChange={handleInputChange}
-          placeholder="e.g., Build a Modern React Website"
+          placeholder="e.g., Help me clean my house this weekend"
           error={errors.title}
           required
           helperText="Minimum 5 characters, maximum 200 characters"

--- a/src/components/ThemeToggle.jsx
+++ b/src/components/ThemeToggle.jsx
@@ -1,0 +1,23 @@
+import { useTheme } from '../contexts/ThemeContext';
+
+export default function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <button
+      onClick={toggleTheme}
+      className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+      aria-label="Toggle theme"
+    >
+      {theme === 'light' ? (
+        <svg className="w-5 h-5 text-gray-700" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+        </svg>
+      ) : (
+        <svg className="w-5 h-5 text-yellow-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/src/contexts/ThemeContext.jsx
+++ b/src/contexts/ThemeContext.jsx
@@ -1,0 +1,47 @@
+import { createContext, useContext, useState, useEffect } from 'react';
+
+const ThemeContext = createContext();
+
+export function ThemeProvider({ children }) {
+  const [theme, setTheme] = useState(() => {
+    // Check localStorage or system preference
+    const savedTheme = localStorage.getItem('theme');
+    if (savedTheme) return savedTheme;
+    
+    // Check system preference
+    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      return 'dark';
+    }
+    return 'light';
+  });
+
+  useEffect(() => {
+    // Update localStorage
+    localStorage.setItem('theme', theme);
+    
+    // Update document class
+    if (theme === 'dark') {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme(prev => prev === 'light' ? 'dark' : 'light');
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within ThemeProvider');
+  }
+  return context;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,6 +4,7 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import './index.css'
 import App from './App.jsx'
 import Login from './pages/Login'
+import { ThemeProvider } from './contexts/ThemeContext'
 
 // Register Service Worker
 if ('serviceWorker' in navigator) {
@@ -20,11 +21,13 @@ if ('serviceWorker' in navigator) {
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <BrowserRouter>
-      <Routes>
-        <Route path="/login" element={<Login />} />
-        <Route path="/*" element={<App />} />
-      </Routes>
-    </BrowserRouter>
+    <ThemeProvider>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/login" element={<Login />} />
+          <Route path="/*" element={<App />} />
+        </Routes>
+      </BrowserRouter>
+    </ThemeProvider>
   </StrictMode>,
 )

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,4 +1,5 @@
 module.exports = {
+  darkMode: 'class',
   content: [
     './index.html',
     './src/**/*.{js,jsx,ts,tsx,html}',


### PR DESCRIPTION
- Add ThemeContext and ThemeProvider for global theme management
- Create ThemeToggle component with sun/moon icons
- Update Navbar with dark mode styles and theme toggle button
- Enable Tailwind dark mode with 'class' strategy
- Update App.jsx with dark mode background transitions
- Change gig title placeholder to more casual example
- Theme persists in localStorage and respects system preference
- Fix Navbar test by wrapping in ThemeProvider
- Add window.matchMedia mock for tests